### PR TITLE
Gateway, program state manager usage

### DIFF
--- a/src/main/java/interface_adapter/Controller/CardController.java
+++ b/src/main/java/interface_adapter/Controller/CardController.java
@@ -3,8 +3,6 @@ package interface_adapter.Controller;
 import use_case.input_boundaries.CardInputBoundary;
 import use_case.output_boundaries.*;
 
-import java.io.IOException;
-
 public class CardController {
     private final CardInputBoundary cardInputBoundary;
     private final DatabaseErrorOutputBoundary databaseErrorOutputBoundary;
@@ -39,7 +37,7 @@ public class CardController {
      */
     public void deleteCard(String cardTerm) {
         if (this.cardInputBoundary.deleteCard(cardTerm)) {
-            this.cardInputBoundary.archive(databaseErrorOutputBoundary);
+            this.cardInputBoundary.delete(databaseErrorOutputBoundary);
         }
     }
 

--- a/src/main/java/interface_adapter/Controller/PackController.java
+++ b/src/main/java/interface_adapter/Controller/PackController.java
@@ -1,13 +1,9 @@
 package interface_adapter.Controller;
 
-import entity.ProgramState;
-import interface_adapter.gateway.IDataInOut;
 import use_case.input_boundaries.PackInputBoundary;
 import use_case.output_boundaries.AddOutputBoundary;
 import use_case.output_boundaries.ChangeOutputBoundary;
 import use_case.output_boundaries.DatabaseErrorOutputBoundary;
-
-import java.io.IOException;
 
 /**
  * A package interface_adapter.Controller that can create/change packname   and   add/delete/search/sort card in a pack.
@@ -45,7 +41,7 @@ public class PackController {
 
     public void deletePack(String packName) {
         if (this.packIB.deletePack(packName)) {
-            this.packIB.archive(databaseErrorOutputBoundary);
+            this.packIB.delete(databaseErrorOutputBoundary);
         }
     }
 //    /**

--- a/src/main/java/interface_adapter/Controller/ReviewController.java
+++ b/src/main/java/interface_adapter/Controller/ReviewController.java
@@ -4,6 +4,7 @@ import entity.Card;
 import entity.ProgramState;
 import interface_adapter.gateway.DataInOut;
 import interface_adapter.gateway.IDataInOut;
+import use_case.input_boundaries.ProgramStateInputBoundary;
 import use_case.input_boundaries.ReviewInputBoundary;
 
 import java.io.IOException;
@@ -12,23 +13,26 @@ import java.io.IOException;
 public class ReviewController {
     private final ReviewInputBoundary reviewIB;
     private final IDataInOut dataInOut = new DataInOut();
-    private final ProgramState programState;
+    private final ProgramStateInputBoundary programStateInputBoundary;
 
-    public ReviewController(ReviewInputBoundary reviewIB, ProgramState programState) {
+    public ReviewController(ReviewInputBoundary reviewIB, ProgramStateInputBoundary programStateInputBoundary) {
         this.reviewIB = reviewIB;
-        this.programState = programState;
+        this.programStateInputBoundary = programStateInputBoundary;
     }
 
     public void next() throws IOException {
         // before going to the next card, update current card's proficiency in database
         Card currCard = reviewIB.getCurrCard();
         if (currCard != null) {
-            dataInOut.write(new String[] {programState.getCurrUser().getName(), programState.getCurrPack().getName()},
+            dataInOut.write(new String[] {programStateInputBoundary.getCurrUserName(), programStateInputBoundary.getCurrPackName()},
                     reviewIB.getCurrCard());
         }
         reviewIB.next();
     }
 
+    /**
+     * This method sets can't recall to true.
+     */
     public void setCantRecall() {
         reviewIB.setCantRecall();
     }

--- a/src/main/java/interface_adapter/gateway/DataInOut.java
+++ b/src/main/java/interface_adapter/gateway/DataInOut.java
@@ -51,9 +51,9 @@ public class DataInOut implements IDataInOut {
     }
 
     @Override
-    public void archive(String[] partialDataPath, Object o) throws IOException {
+    public void delete(String[] partialDataPath, Object o) throws IOException {
         Writer writer = this.factory.getWriter(partialDataPath, o);
-        writer.archive();
+        writer.delete();
     }
 
     /**

--- a/src/main/java/interface_adapter/gateway/IDataInOut.java
+++ b/src/main/java/interface_adapter/gateway/IDataInOut.java
@@ -14,7 +14,7 @@ public interface IDataInOut {
 
     void write(String[] partialDataPath, String oldName, Object newO) throws IOException;
 
-    void archive(String[] partialDataPath, Object o) throws IOException;
+    void delete(String[] partialDataPath, Object o) throws IOException;
 
     HashMap<String, String> initialLoad() throws IOException;
 

--- a/src/main/java/interface_adapter/gateway/datain/CardWriter.java
+++ b/src/main/java/interface_adapter/gateway/datain/CardWriter.java
@@ -54,15 +54,19 @@ public class CardWriter extends Writer {
     }
 
     /**
-     * Archive a card. Effectively, this card is deleted because it won't be loaded next time the program runs.
+     * Delete a card.
      *
      */
     @Override
-    public void archive() throws IOException {
-        new File("user_data/users/" + this.username + "/packages/" + this.packname +
-                "/archived_cards/").mkdirs();
-        Files.move(new File("user_data/users/" + this.username + "/packages/" + this.packname + "/cards/" +
-                this.card.getTerm() + ".txt").toPath(), new File("user_data/users/" + this.username +
-                "/packages/" + this.packname + "/archived_cards/" + this.card.getTerm() + ".txt").toPath());
-    } // FIXME: same problem as UserWriter.archive
+    public void delete() throws IOException {
+        new File("user_data/users/" + this.username + "/packages/" + this.packname + "/cards/" +
+                this.card.getTerm() + ".txt").delete();
+    }
+
+    //Test
+    public static void main(String[] args) throws IOException {
+        String[] path = new String[]{"test_user_1", "packA"};
+        CardWriter cw = new CardWriter(path, new Card("Card1", "card1definition"));
+        cw.delete();
+    }
 }

--- a/src/main/java/interface_adapter/gateway/datain/PackWriter.java
+++ b/src/main/java/interface_adapter/gateway/datain/PackWriter.java
@@ -47,15 +47,17 @@ public class PackWriter extends Writer {
     }
 
     /**
-     * Archive a package. Effectively, this package is deleted because it won't be loaded next time the program runs.
-     *
-     * @throws IOException
+     * Delete a pack.
      */
     @Override
-    public void archive() throws IOException {
-        new File("user_data/users/" + this.username + "/archived_packages/").mkdirs();
-        Files.move(new File("user_data/users/" + this.username + "/packages/" + this.pack.getName()).toPath(),
-                new File("user_data/users/" + this.username + "/archived_packages/" +
-                        this.pack.getName()).toPath());
-    } // FIXME: same problem as UserWriter.archive.
+    public void delete() {
+        File packFolder = new File("user_data/users/" + this.username + "/packages/" + this.pack.getName());
+        File[] cards = packFolder.listFiles();
+        if(cards!=null) { // meaning packFolder is non-empty (contains some cards)
+            for(File c: cards) {
+                c.delete();
+            }
+        }
+        packFolder.delete();
+    }
 }

--- a/src/main/java/interface_adapter/gateway/datain/UserWriter.java
+++ b/src/main/java/interface_adapter/gateway/datain/UserWriter.java
@@ -52,15 +52,17 @@ public class UserWriter extends Writer {
     }
 
     /**
-     * Archive a user. Effectively, this user is deleted because it won't be loaded next time the program runs.
-     *
-     * @throws IOException
+     * Delete a user.
      */
     @Override
-    public void archive() throws IOException {
-        new File("user_data/archived_users/").mkdirs();
-        Files.move(new File("user_data/users/" + user.getName()).toPath(),
-                new File("user_data/archived_users/" + user.getName()).toPath());
-    // FIXME: may be deleted completely without archiving, cuz move throws exception if target path exists.
+    public void delete() {
+        File userFolder = new File("user_data/users/" + user.getName());
+        File[] packs = userFolder.listFiles();
+        if(packs!=null) { // meaning userFolder is non-empty (contains some packs)
+            for(File p: packs) {
+                p.delete();
+            }
+        }
+        userFolder.delete();
     }
 }

--- a/src/main/java/interface_adapter/gateway/datain/Writer.java
+++ b/src/main/java/interface_adapter/gateway/datain/Writer.java
@@ -32,8 +32,8 @@ public abstract class Writer {
     public abstract void write(String oldName, Object newO) throws IOException;
 
     /**
-     * Archive the object in database (store in database but won't load in future)
+     * Delete the object in database.
      *
      */
-    public abstract void archive() throws IOException;
+    public abstract void delete() throws IOException;
 }

--- a/src/main/java/interface_adapter/gateway/dataout/Loader.java
+++ b/src/main/java/interface_adapter/gateway/dataout/Loader.java
@@ -106,13 +106,23 @@ public class Loader {
      */
     private void putCard(String cardPath, Pack pack) throws IOException {
         BufferedReader cardInfoFileReader = Files.newBufferedReader(Path.of(cardPath));
+        String cardFileName = Path.of(cardPath).getFileName().toString();
+        String cardTerm = cardFileName.substring(0, cardFileName.lastIndexOf("."));
+
         String cardInfo = cardInfoFileReader.readLine();
         cardInfoFileReader.close();
-        String cardTerm = Path.of(cardPath).getFileName().toString();
-        String cardDefinition = cardInfo.split(",")[0];
-        String cardProficiency = cardInfo.split(",")[1];
+        String cardDefinition = cardInfo.substring(0, cardInfo.lastIndexOf(","));
+        String cardProficiency = cardInfo.substring(cardInfo.length() - 1);
         Card card = new Card(cardTerm, cardDefinition);
         card.setProficiency(Integer.parseInt(cardProficiency));
         pack.addCard(card);
+    }
+
+    // Test
+    public static void main(String[] args) throws IOException {
+        Loader loader = new Loader();
+        User user = new User("Xing", "password");
+        loader.userLoad(user);
+        System.out.println(user.getPackageList().get(0).getCardList());
     }
 }

--- a/src/main/java/interface_adapter/gateway/dataout/Reader.java
+++ b/src/main/java/interface_adapter/gateway/dataout/Reader.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 /**
  * This class is a helper to Loader. Other classes shouldn't need it.
  */
-public class Reader {
+class Reader {
 
     /**
      * Return a complete list of file paths, in strings, leading to up till usernames.

--- a/src/main/java/use_case/input_boundaries/ManagerInputBoundary.java
+++ b/src/main/java/use_case/input_boundaries/ManagerInputBoundary.java
@@ -5,5 +5,5 @@ import use_case.output_boundaries.DatabaseErrorOutputBoundary;
 public interface ManagerInputBoundary {
     public void write(DatabaseErrorOutputBoundary databaseErrorOutputBoundary);
     public void write(String oldName, DatabaseErrorOutputBoundary databaseErrorOutputBoundary);
-    public void archive(DatabaseErrorOutputBoundary databaseErrorOutputBoundary);
+    public void delete(DatabaseErrorOutputBoundary databaseErrorOutputBoundary);
 }

--- a/src/main/java/use_case/input_boundaries/ProgramStateInputBoundary.java
+++ b/src/main/java/use_case/input_boundaries/ProgramStateInputBoundary.java
@@ -6,7 +6,9 @@ import java.beans.PropertyChangeListener;
 
 public interface ProgramStateInputBoundary {
     User getCurrUser();
+    String getCurrUserName();
     Pack getCurrPack();
+    String getCurrPackName();
     Card getCurrCard();
     void setCurrUser(User user);
     void setCurrPack(String packname);

--- a/src/main/java/use_case/manager/Manager.java
+++ b/src/main/java/use_case/manager/Manager.java
@@ -87,10 +87,11 @@ public abstract class Manager<T> {
 
     /**
      * Archive (delete and store) the required object into database.
+     * @param databaseErrorOutputBoundary an output boundary that gets the error message if fails connect to database.
      */
-    public void archive(DatabaseErrorOutputBoundary databaseErrorOutputBoundary) {
+    public void delete(DatabaseErrorOutputBoundary databaseErrorOutputBoundary) {
         try {
-            dataInOut.archive(findPartialDataPath(), currItem);
+            dataInOut.delete(findPartialDataPath(), currItem);
         } catch (IOException e) {
             databaseErrorOutputBoundary.presentWriteErrMsg();
         }

--- a/src/main/java/use_case/manager/Manager.java
+++ b/src/main/java/use_case/manager/Manager.java
@@ -74,6 +74,9 @@ public abstract class Manager<T> {
         }
     }
 
+    /**
+     * Write the object (with its name changed) into database.
+     */
     public void write(String oldName, DatabaseErrorOutputBoundary databaseErrorOutputBoundary) {
         try {
             dataInOut.write(findPartialDataPath(), oldName, currItem);

--- a/src/main/java/use_case/manager/ProgramStateManager.java
+++ b/src/main/java/use_case/manager/ProgramStateManager.java
@@ -25,8 +25,24 @@ public class ProgramStateManager implements ProgramStateInputBoundary {
     }
 
     @Override
+    public String getCurrUserName() {
+        if (ps.getCurrUser() != null) {
+            return ps.getCurrUser().getName();
+        }
+        return null;
+    }
+
+    @Override
     public Pack getCurrPack() {
         return ps.getCurrPack();
+    }
+
+    @Override
+    public String getCurrPackName() {
+        if (ps.getCurrPack() != null) {
+            return ps.getCurrPack().getName();
+        }
+        return null;
     }
 
     @Override

--- a/src/test/java/interface_adapter/ReviewTest.java
+++ b/src/test/java/interface_adapter/ReviewTest.java
@@ -9,7 +9,9 @@ import interface_adapter.presenters.ReviewPresenter;
 import org.junit.Before;
 import org.junit.Test;
 import use_case.generator.ReviewGenerator;
+import use_case.input_boundaries.ProgramStateInputBoundary;
 import use_case.input_boundaries.ReviewInputBoundary;
+import use_case.manager.ProgramStateManager;
 import use_case.output_boundaries.ReviewOutputBoundary;
 
 import java.io.IOException;
@@ -59,9 +61,9 @@ public class ReviewTest {
         reviewOutputBoundary = new ReviewPresenter();
         // notice in the line of code below I didn't get pack from program state
         reviewInputBoundary = new ReviewGenerator(pack, reviewOutputBoundary);
-        ProgramState state = new ProgramState();
+        ProgramStateInputBoundary state = new ProgramStateManager();
         state.setCurrUser(new User("xing", "password"));
-        state.setCurrPack(pack); // at a review session, program state should be at (xing/vocabulary/null)
+        state.setCurrPack(pack.getName()); // at a review session, program state should be at (xing/vocabulary/null)
         reviewController = new ReviewController(reviewInputBoundary, state);
     }
 


### PR DESCRIPTION
1. Changed `archive` to `delete`. Deleted items no longer stored in database. This eliminate errors when archiving an object with same name as objects already in archived folder.
2. Revised card loader: split card proficiency and definition by the last index of comma.
3. Changed instance variable type in `ReviewController`: from entity (ProgramState) to usecase (ProgramStateManager).